### PR TITLE
Cache whole season on location page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 obj/
+backup/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/

--- a/Muddi.ShiftPlanner.Client/Components/DisplayNextShiftsComponent.razor.cs
+++ b/Muddi.ShiftPlanner.Client/Components/DisplayNextShiftsComponent.razor.cs
@@ -19,8 +19,8 @@ public partial class DisplayNextShiftsComponent : IDisposable
 	[Inject] private DialogService DialogService { get; set; } = default!;
 	[Inject] public IBlazorDownloadFileService BlazorDownloadFileService { get; set; }
 	[CascadingParameter] private Task<AuthenticationState> AuthStateTask { get; set; }
-	private List<Appointment>? _myShifts;
-	private List<Appointment>? _freeShifts;
+	private List<DayAppointment>? _myShifts;
+	private List<DayAppointment>? _freeShifts;
 
 	protected override async Task OnInitializedAsync()
 	{
@@ -37,12 +37,12 @@ public partial class DisplayNextShiftsComponent : IDisposable
 			var shifts = await ShiftService.GetAllShiftsFromUser(authState.User, 6, DateTime.UtcNow);
 			_myShifts = new(shifts.Select(s => s.ToAppointment()));
 			var availableShifts = await ShiftService.GetAllAvailableShifts(12, DateTime.UtcNow);
-			_freeShifts = new(availableShifts.Select(s => s.ToAppointment()));
+			_freeShifts = [..availableShifts.Select(s => s.ToAppointment())];
 			await InvokeAsync(StateHasChanged);
 		}
 	}
 
-	private static string MakeLocationUri(Appointment appointment, bool showOnlyUserShift = true)
+	private static string MakeLocationUri(DayAppointment appointment, bool showOnlyUserShift = true)
 	{
 		var query = HttpUtility.ParseQueryString(string.Empty);
 		query[nameof(LocationPage.StartDate)] = appointment.LocalStartTime.ToString("yyyy-MM-dd");

--- a/Muddi.ShiftPlanner.Client/Entities/Appointment.cs
+++ b/Muddi.ShiftPlanner.Client/Entities/Appointment.cs
@@ -2,24 +2,45 @@
 
 namespace Muddi.ShiftPlanner.Client.Entities;
 
-public class Appointment
+public class WeekAppointment : Appointment
 {
-	public Appointment(Shift shift)
-		: this(shift.StartTime, shift.EndTime)
+	public int AvailableShifts { get; init; }
+	public int TotalShifts { get; init; }
+
+	public WeekAppointment(DateTime startTime, DateTime endTime, string title, int availableShifts, int totalShifts) :
+		base(startTime, endTime, title)
+	{
+		AvailableShifts = availableShifts;
+		TotalShifts = totalShifts;
+	}
+}
+
+public class DayAppointment : Appointment
+{
+	public Shift Shift { get; init; }
+
+	public DayAppointment(Shift shift) : base(shift.StartTime, shift.EndTime)
 	{
 		Shift = shift;
-		Title = StartTimeWithTimeShift.ToString("HH:mm") + " - " + EndTimeWithTimeShift.ToString("HH:mm") + "\n" 
-		        + shift.User.Name 
+		Title = StartTimeWithTimeShift.ToString("HH:mm") + " - " + EndTimeWithTimeShift.ToString("HH:mm") + "\n"
+		        + shift.User.Name
 		        + "\n" + shift.Type.Name;
+		
 	}
 
-	public Appointment(DateTime startTime, DateTime endTime, string title)
+	public DateTime StartTimeWithTimeShift => LocalStartTime + Shift.Type.StartingTimeShift;
+	public  DateTime EndTimeWithTimeShift => LocalEndTime + Shift.Type.StartingTimeShift;
+}
+
+public abstract class Appointment
+{
+	protected Appointment(DateTime startTime, DateTime endTime, string title)
 		: this(startTime, endTime)
 	{
 		Title = title;
 	}
 
-	private Appointment(DateTime startTime, DateTime endTime)
+	protected Appointment(DateTime startTime, DateTime endTime)
 	{
 		LocalStartTime = startTime.ToLocalTime();
 		LocalEndTime = endTime.ToLocalTime();
@@ -29,7 +50,4 @@ public class Appointment
 	public DateTime LocalStartTime { get; init; }
 	public DateTime LocalEndTime { get; init; }
 	public string Title { get; init; }
-	public Shift? Shift { get; init; }
-	public DateTime StartTimeWithTimeShift => LocalStartTime + (Shift?.Type.StartingTimeShift ?? TimeSpan.Zero);
-	public DateTime EndTimeWithTimeShift => LocalEndTime + (Shift?.Type.StartingTimeShift ?? TimeSpan.Zero);
 }

--- a/Muddi.ShiftPlanner.Client/Extensions/DialogServiceExtensions.cs
+++ b/Muddi.ShiftPlanner.Client/Extensions/DialogServiceExtensions.cs
@@ -13,11 +13,13 @@ public static class DialogServiceExtensions
 			ApiException apiException => $"{apiException.Message}\r\n{apiException.Content}",
 			_ => ex.Message + "\r\n" + ex.InnerException?.Message
 		};
-		
+		Console.WriteLine(ex);
 		return dialogService.Error(message, title ?? $"Error - {ex.GetType().Name}");
 	}
+
 	public static Task Error(this DialogService dialogService, string errorText, string title = "Error")
 	{
-		return dialogService.OpenAsync<ErrorDialog>(title, new Dictionary<string, object>(){[nameof(ErrorDialog.Text)] = errorText});
+		return dialogService.OpenAsync<ErrorDialog>(title,
+			new Dictionary<string, object>() { [nameof(ErrorDialog.Text)] = errorText });
 	}
 }

--- a/Muddi.ShiftPlanner.Client/Extensions/RenderExtensions.cs
+++ b/Muddi.ShiftPlanner.Client/Extensions/RenderExtensions.cs
@@ -1,9 +1,12 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Muddi.ShiftPlanner.Client.Entities;
 using Muddi.ShiftPlanner.Client.Services;
 using Muddi.ShiftPlanner.Shared;
 using Muddi.ShiftPlanner.Shared.Entities;
 using Radzen;
+using Radzen.Blazor.Rendering;
+using Appointment = Muddi.ShiftPlanner.Client.Entities.Appointment;
 
 namespace Muddi.ShiftPlanner.Client;
 
@@ -38,19 +41,18 @@ public static class RenderExtensions
 	{
 		args.Attributes["style"] = string.Empty;
 
-		//WeekView (quite hacky ;) )
-		if (args.Data.Shift is not { } shift)
+		if (args.Data is WeekAppointment weekAppointment)
 		{
-			var match = Regex.Match(args.Data.Title, @"(\d*?)\/(\d*?)\n");
-			var from = double.Parse(match.Groups[1].Value);
-			var to = double.Parse(match.Groups[2].Value);
-			int num = Convert.ToInt32(0x33 + (136.0 * from / to));
-			var numHex = num.ToString("X2");
-
-			args.Attributes["style"] += $"background: #000000{numHex}";
+			var from = weekAppointment.AvailableShifts;
+			var to = weekAppointment.TotalShifts;
+			double num = Convert.ToInt32(40 + 40 * from / to) / 100.0;
+			args.Attributes["style"] = $"background: rgb(0,0,0,{num.ToInvariantString()});";
 			return;
 		}
 
+		if (args.Data is not DayAppointment dayAppointment)
+			throw new NotSupportedException("Unknown appointment type" + args.Data.GetType());
+		var shift = dayAppointment.Shift;
 
 		//DayView
 		if (shift.User == Mappers.NotAssignedEmployee)

--- a/Muddi.ShiftPlanner.Client/Extensions/ShiftExtensions.cs
+++ b/Muddi.ShiftPlanner.Client/Extensions/ShiftExtensions.cs
@@ -5,5 +5,5 @@ namespace Muddi.ShiftPlanner.Client;
 
 public static class ShiftExtensions
 {
-	public static Appointment ToAppointment(this Shift shift) => new(shift);
+	public static DayAppointment ToAppointment(this Shift shift) => new(shift);
 }

--- a/Muddi.ShiftPlanner.Client/Pages/Locations/LocationPage.razor
+++ b/Muddi.ShiftPlanner.Client/Pages/Locations/LocationPage.razor
@@ -13,6 +13,15 @@
 else
 {
     <div style="position:relative;">
+        @if (_shifts.Count == 0)
+        {
+            <div class="d-flex  justify-content-center position-absolute w-100 h-100" style="z-index: 10; backdrop-filter: blur(2px);">
+				<div class="d-flex align-items-center flex-column" style="margin-top: 6rem">
+					<LoadingSpinner/>
+					<h3 style="color: var(--main-primary)">MUDDI sucht Schichten...</h3>
+				</div>
+			</div>
+        }
         <div class="flex-row d-flex justify-content-between">
             <RadzenButton Text="Nur meine Schichten"
                           class="only-my-shifts-button"

--- a/Muddi.ShiftPlanner.Client/Pages/Locations/LocationPage.razor.cs
+++ b/Muddi.ShiftPlanner.Client/Pages/Locations/LocationPage.razor.cs
@@ -1,9 +1,6 @@
-﻿using System.Collections.Concurrent;
-using System.Diagnostics;
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.JSInterop;
 using Muddi.ShiftPlanner.Client.Components;
@@ -12,10 +9,8 @@ using Muddi.ShiftPlanner.Client.Services;
 using Muddi.ShiftPlanner.Client.Shared;
 using Muddi.ShiftPlanner.Shared;
 using Muddi.ShiftPlanner.Shared.Contracts.v1;
-using Muddi.ShiftPlanner.Shared.Contracts.v1.Requests;
 using Muddi.ShiftPlanner.Shared.Contracts.v1.Responses;
 using Muddi.ShiftPlanner.Shared.Entities;
-using Muddi.ShiftPlanner.Shared.Exceptions;
 using Radzen;
 using Radzen.Blazor;
 
@@ -95,7 +90,7 @@ public partial class LocationPage
 
 			_userKeycloakId = _user.GetKeycloakId();
 			_isAdmin = _user.IsInRole(ApiRoles.Admin);
-			await ForceReloadScheduler();
+			await SetShifts(SelectedViewIndex);
 		}
 		catch (Exception ex)
 		{
@@ -107,8 +102,7 @@ public partial class LocationPage
 
 	Task ForceReloadScheduler()
 	{
-		_oldStart = default;
-		_oldEnd = default;
+		_shifts.Clear();
 		return _scheduler?.Reload() ?? Task.CompletedTask;
 	}
 
@@ -120,6 +114,8 @@ public partial class LocationPage
 
 	private async Task OnSlotSelect(DateTime startTime, ShiftType? type = null)
 	{
+		if (_location is null || _user is null)
+			return;
 		if (type is { OnlyAssignableByAdmin: true } && !_isAdmin)
 		{
 			await DialogService.Confirm($"Leider dürfen nur Admins '{type.Name}' Nutzer*Innen auswählen.");
@@ -169,6 +165,7 @@ public partial class LocationPage
 		{
 			SelectedViewIndex = DayViewIndex;
 			StartDate = args.Start.Date;
+			await SetShifts(SelectedViewIndex, true);
 			return;
 		}
 
@@ -194,50 +191,37 @@ public partial class LocationPage
 	}
 
 	// Never call StateHasChanged in AppointmentRender - would lead to infinite loop
+	//TODO[perf] OnAppointmentRender will be called twice, on day/week leave and on day/week come
 	private void OnAppointmentRender(SchedulerAppointmentRenderEventArgs<Appointment> args)
-		=> args.SetAppointmentRenderStyle(_userKeycloakId);
+	{
+		args.SetAppointmentRenderStyle(_userKeycloakId);
+	}
 
 
 	private void OnSlotRender(SchedulerSlotRenderEventArgs args)
 		=> args.SetSlotRenderStyle(_location!.Containers);
 
 
-	private DateTime _oldStart;
-	private DateTime _oldEnd;
+	private readonly SemaphoreSlim _semaphore = new(1, 1);
 
-
-	private SemaphoreSlim _semaphore = new(1, 1);
-
-	private async Task LoadShifts(SchedulerLoadDataEventArgs arg)
+	private async Task SetShifts(int idx, bool invokeStateHasChanged = false)
 	{
 		await _semaphore.WaitAsync();
 		try
 		{
-			var idx = GetSelectedViewIndex();
-			bool shiftsAny = _shifts.Any();
-			bool dateNotChanged = arg.Start == _oldStart && arg.End == _oldEnd;
-			//I dont know why, but we need this
-			bool isCorrectFormat = (idx == WeekViewIndex && arg.End - arg.Start > TimeSpan.FromDays(1))
-			                       || (idx == DayViewIndex && arg.End - arg.Start <= TimeSpan.FromDays(1));
-			if ((shiftsAny && dateNotChanged) || !isCorrectFormat)
-			{
-				return;
-			}
-
-			_oldStart = arg.Start;
-			_oldEnd = arg.End;
 			_shifts.Clear();
-
+			var start = ShiftService.CurrentSeason.StartDate;
+			var end = ShiftService.CurrentSeason.EndDate;
 			switch (idx)
 			{
 				case WeekViewIndex:
 				{
 					//Week view
 					var myShifts =
-						(await ShiftService.GetAllShiftsFromLocationAsync(Id, arg.Start, arg.End, _userKeycloakId))
+						(await ShiftService.GetAllShiftsFromLocationAsync(Id, start, end, _userKeycloakId))
 						.ToList();
 					var shiftTypes =
-						await ShiftService.GetAllAvailableShiftTypesFromLocationAsync(Id, arg.Start, arg.End);
+						await ShiftService.GetAllAvailableShiftTypesFromLocationAsync(Id, start, end);
 					var group = shiftTypes.GroupBy(st => new { st.Start, st.End });
 					var appointments = group.Select(g => CreateNewAppointment(g.Key.Start, g.Key.End, g, myShifts));
 					_shifts = appointments.ToList();
@@ -256,6 +240,9 @@ public partial class LocationPage
 					break;
 				}
 			}
+
+			if (invokeStateHasChanged)
+				await InvokeAsync(StateHasChanged);
 		}
 		finally
 		{
@@ -275,8 +262,9 @@ public partial class LocationPage
 			getShiftTypesResponses = getShiftTypesResponses.Where(s => s.Type.OnlyAssignableByAdmin == false);
 
 		var arr = getShiftTypesResponses as GetShiftTypesCountResponse[] ?? getShiftTypesResponses.ToArray();
-		var available = Math.Max(0, arr.Sum(s => s.AvailableCount));
 		var total = arr.Sum(s => s.TotalCount);
+		var available = Math.Max(0, arr.Sum(s => s.AvailableCount));
+		// var available = Random.Shared.Next(0, total + 1);
 		var title = $"{available}/{total}\nfreie Schicht{(available != 1 ? "en" : "")}";
 		return new WeekAppointment(start, end, title, available, total);
 	}
@@ -290,14 +278,17 @@ public partial class LocationPage
 
 	private void UpdateQueryUri(DateTime date = default)
 	{
-		var sDate = (date == default ? _scheduler?.CurrentDate.Date : date)?.ToString("yyyy-MM-dd");
+		if (_scheduler is null)
+			return;
+		StartDate = (date == default ? _scheduler.CurrentDate.Date : date);
 		var queryParams = new Dictionary<string, object?>
 		{
 			[nameof(ShowOnlyUsersShifts)] = ShowOnlyUsersShifts,
-			[nameof(StartDate)] = sDate,
+			[nameof(StartDate)] = StartDate.ToString("yyyy-MM-dd"),
 			[nameof(SelectedViewIndex)] = SelectedViewIndex
 		};
 		_ = JsRuntime.InvokeVoidAsync("updateQueryParameters", queryParams).AsTask();
+		InvokeAsync(StateHasChanged); //For the DatePicker
 	}
 
 	private void ShowOnlyUserShiftsButtonPressed()
@@ -330,4 +321,13 @@ public partial class LocationPage
 
 	private const int WeekViewIndex = 1;
 	private const int DayViewIndex = 0;
+
+	private void LoadShifts(SchedulerLoadDataEventArgs obj)
+	{
+		UpdateQueryUri();
+		var current = GetSelectedViewIndex();
+		if (SelectedViewIndex == current && _shifts.Count > 0)
+			return;
+		_ = SetShifts(current, true);
+	}
 }


### PR DESCRIPTION
When going on a location page we now cache all shifts of the whole season for that location instead of fetching the data when the user scrolls between dates. This make the app more responsive