### PR TITLE
feat: implement admin only location type

### DIFF
--- a/Muddi.ShiftPlanner.Client/Pages/Admin/Locations/AddLocationTypeDialog.razor
+++ b/Muddi.ShiftPlanner.Client/Pages/Admin/Locations/AddLocationTypeDialog.razor
@@ -7,6 +7,12 @@
 	<div class="col-md-8">
 		<RadzenTextBox @bind-Value="EntityToEdit.Name" Placeholder="Name"></RadzenTextBox>
 	</div>
+	<div class="col-md-4 align-items-center d-flex">
+		<RadzenLabel Text="Admin Only"/>
+	</div>
+	<div class="col-md-8">
+		<RadzenCheckBox @bind-Value="EntityToEdit.AdminOnly" />
+	</div>
 </div>
 <div class="row mb-3 mt-4">
 	<div class="col-md-12 text-right">
@@ -17,8 +23,12 @@
 
 @code {
 
-	protected override Task Create() 
-		=> ShiftApi.CreateLocationType(new() { Name = EntityToEdit.Name });
+	protected override Task Create()
+		=> ShiftApi.CreateLocationType(new()
+		{
+			Name = EntityToEdit.Name,
+			AdminOnly = EntityToEdit.AdminOnly
+		});
 
 	protected override Task Update()
 	{

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/Containers/CreateEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/Containers/CreateEndpoint.cs
@@ -1,5 +1,6 @@
 ﻿using Mapster;
 using Microsoft.EntityFrameworkCore;
+using Muddi.ShiftPlanner.Server.Api.Extensions;
 using Muddi.ShiftPlanner.Server.Database.Contexts;
 using Muddi.ShiftPlanner.Server.Database.Entities;
 
@@ -30,6 +31,7 @@ public class CreateEndpoint : CrudCreateEndpoint<CreateContainerRequest, GetCont
 		}
 		
 		var location = await Database.ShiftLocations
+			.CheckAdminOnly(User)
 			.Include(t => t.Containers)
 			.FirstOrDefaultAsync(t => t.Id == req.LocationId, cancellationToken: ct);
 		if (location is null)

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/Containers/GetAllEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/Containers/GetAllEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿using FastEndpoints;
 using Mapster;
 using Microsoft.EntityFrameworkCore;
+using Muddi.ShiftPlanner.Server.Api.Extensions;
 using Muddi.ShiftPlanner.Server.Database.Contexts;
 
 namespace Muddi.ShiftPlanner.Server.Api.Endpoints.Containers;
@@ -19,6 +20,7 @@ public class GetAllEndpoint : CrudGetAllEndpoint<GetContainerRequest, GetContain
 	public override async Task<List<GetContainerResponse>?> CrudExecuteAsync(GetContainerRequest req, CancellationToken ct)
 	{
 		return await Database.ShiftLocations
+			.CheckAdminOnly(User)
 			.Include(t => t.Type)
 			.Where(q => q.Season.Id == req.SeasonId)
 			.OrderBy(sl => sl.Containers.Min(c => c.Start))

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/LocationTypes/CreateEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/LocationTypes/CreateEndpoint.cs
@@ -20,7 +20,8 @@ public class CreateEndpoint : CrudCreateEndpoint<CreateLocationTypeRequest, GetL
 		var type = new ShiftLocationTypeEntity
 		{
 			Id = Guid.NewGuid(),
-			Name = req.Name
+			Name = req.Name,
+			AdminOnly = req.AdminOnly
 		};
 		Database.Add(type);
 		await Database.SaveChangesAsync(ct);

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/ExportToExcelEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/ExportToExcelEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿using System.Web;
 using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
+using Muddi.ShiftPlanner.Server.Api.Extensions;
 using Muddi.ShiftPlanner.Server.Api.Services;
 using Muddi.ShiftPlanner.Server.Database.Contexts;
 using Muddi.ShiftPlanner.Shared.Contracts.v1;
@@ -26,6 +27,7 @@ public class ExportToExcelEndpoint : Endpoint<ExportToExcelRequest>
 	public override async Task HandleAsync(ExportToExcelRequest req, CancellationToken ct)
 	{
 		var location = await _database.ShiftLocations
+			.CheckAdminOnly(User)
 			.Include(l => l.Containers)
 			.ThenInclude(c => c.Framework)
 			.ThenInclude(f => f.ShiftTypeCounts)

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/GetAllEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/GetAllEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿using FastEndpoints;
 using Mapster;
 using Microsoft.EntityFrameworkCore;
+using Muddi.ShiftPlanner.Server.Api.Extensions;
 using Muddi.ShiftPlanner.Server.Database.Contexts;
 using Muddi.ShiftPlanner.Shared.Contracts.v1;
 
@@ -21,6 +22,7 @@ public class GetAllEndpoint : CrudGetAllEndpoint<GetLocationRequest, GetLocation
 	public override async Task<List<GetLocationResponse>?> CrudExecuteAsync(GetLocationRequest req,
 		CancellationToken ct) =>
 		await Database.ShiftLocations
+			.CheckAdminOnly(User)
 			.Include(l => l.Type)
 			.Where(l => l.Season.Id == req.SeasonId)
 			.OrderBy(l => l.Containers.Min(x => x.Start)) //First order by starting time

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/GetEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/GetEndpoint.cs
@@ -1,5 +1,6 @@
 ﻿using Mapster;
 using Microsoft.EntityFrameworkCore;
+using Muddi.ShiftPlanner.Server.Api.Extensions;
 using Muddi.ShiftPlanner.Server.Database.Contexts;
 using Muddi.ShiftPlanner.Shared.Contracts.v1;
 
@@ -19,6 +20,7 @@ public class GetEndpoint : CrudGetEndpoint<GetLocationResponse>
 
 	public override async Task<GetLocationResponse?> CrudExecuteAsync(Guid id, CancellationToken ct) =>
 		(await Database.ShiftLocations
+			.CheckAdminOnly(User)
 			.Include(t => t.Type)
 			.Include(t => t.Containers)
 			.ThenInclude(c => c.Framework)

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/Shifts/AddShiftEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/Shifts/AddShiftEndpoint.cs
@@ -24,6 +24,7 @@ public class AddShiftEndpoint : CrudEndpoint<CreateShiftRequest, DefaultCreateRe
 	public override async Task HandleAsync(CreateShiftRequest req, CancellationToken ct)
 	{
 		var location = await Database.ShiftLocations
+			.CheckAdminOnly(User)
 			.Include(l => l.Containers.Where(t => req.Start >= t.Start && req.Start < t.End))
 			.ThenInclude(c => c.Framework)
 			.Include(l => l.Containers.Where(t => req.Start >= t.Start && req.Start < t.End))

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/Shifts/GetAllAvailableShiftTypesEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/Shifts/GetAllAvailableShiftTypesEndpoint.cs
@@ -1,5 +1,6 @@
 ﻿using DocumentFormat.OpenXml.Math;
 using Microsoft.EntityFrameworkCore;
+using Muddi.ShiftPlanner.Server.Api.Extensions;
 using Muddi.ShiftPlanner.Server.Api.Services;
 using Muddi.ShiftPlanner.Server.Database.Contexts;
 using Muddi.ShiftPlanner.Shared.Contracts.v1;
@@ -23,6 +24,7 @@ public class GetAllAvailableShiftTypesEndpoint : CrudGetAllEndpoint<GetAvailable
 		var start = request.StartTime?.ToUniversalTime() ?? DateTime.UnixEpoch;
 		var end = request.EndTime?.ToUniversalTime() ?? DateTime.MaxValue;
 		var location = await Database.ShiftLocations
+			.CheckAdminOnly(User)
 			.Include(l => l.Containers.Where(c => c.Start >= start && c.Start < end))
 			.ThenInclude(c => c.Framework)
 			.ThenInclude(f => f.ShiftTypeCounts)

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/Shifts/GetAllEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/Shifts/GetAllEndpoint.cs
@@ -31,6 +31,7 @@ public class GetAllEndpoint : CrudGetAllEndpoint<GetAllShiftsForLocationRequest,
 		var start = req.Start.ToUniversalTime();
 		var end = req.End.ToUniversalTime();
 		var location = await Database.ShiftLocations
+			.CheckAdminOnly(User)
 			.Include(l => l.Containers)
 			.ThenInclude(c => c.Shifts.Where(s =>
 				// ReSharper disable once SimplifyConditionalTernaryExpression

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/Shifts/GetAllShiftsCountEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/Shifts/GetAllShiftsCountEndpoint.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
+using Muddi.ShiftPlanner.Server.Api.Extensions;
 using Muddi.ShiftPlanner.Server.Database.Contexts;
 using Muddi.ShiftPlanner.Shared.Contracts.v1;
 using Namotion.Reflection;
@@ -21,6 +22,7 @@ public class GetAllShiftsCountEndpoint : CrudGetAllEndpoint<GetShiftsCountReques
 	public override async Task<List<GetShiftsCountResponse>?> CrudExecuteAsync(GetShiftsCountRequest request, CancellationToken ct)
 	{
 		var total = await Database.ShiftLocations
+			.CheckAdminOnly(User)
 			.Where(l => l.Season.Id == request.SeasonId)
 			.GroupBy(s => s.Id)
 			.Select(l =>

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/Shifts/GetShiftsCountEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/Locations/Shifts/GetShiftsCountEndpoint.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Muddi.ShiftPlanner.Server.Api.Extensions;
 using Muddi.ShiftPlanner.Server.Database.Contexts;
 using Muddi.ShiftPlanner.Shared.Contracts.v1;
 
@@ -19,6 +20,7 @@ public class GetShiftsCountEndpoint : CrudGetEndpoint<GetShiftsCountResponse>
 	public override async Task<GetShiftsCountResponse?> CrudExecuteAsync(Guid id, CancellationToken ct)
 	{
 		var total = await Database.ShiftLocations
+			.CheckAdminOnly(User)
 			.Where(l => l.Id == id)
 			.SumAsync(l => l.Containers
 				.Sum(c => c.TotalShifts * c.Framework.ShiftTypeCounts

--- a/Muddi.ShiftPlanner.Server.Api/Extensions/ShiftLocationEntityExtensions.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Extensions/ShiftLocationEntityExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using Muddi.ShiftPlanner.Server.Database.Entities;
+using Muddi.ShiftPlanner.Shared.Contracts.v1;
+
+namespace Muddi.ShiftPlanner.Server.Api.Extensions;
+
+public static class ShiftLocationEntityExtensions
+{
+	public static IQueryable<ShiftLocationEntity> CheckAdminOnly(this IQueryable<ShiftLocationEntity> shiftLocations,
+		ClaimsPrincipal user)
+	{
+		return user.IsInRole(ApiRoles.Admin)
+			? shiftLocations
+			: shiftLocations.Where(x => x.Type.AdminOnly == false);
+	}
+}

--- a/Muddi.ShiftPlanner.Server.Database/Entities/ShiftLocationTypeEntity.cs
+++ b/Muddi.ShiftPlanner.Server.Database/Entities/ShiftLocationTypeEntity.cs
@@ -4,4 +4,5 @@ public class ShiftLocationTypeEntity
 {
 	public Guid Id { get; set; }
 	public string Name { get; set; }
+	public bool AdminOnly { get; set; }
 }

--- a/Muddi.ShiftPlanner.Server.Database/Migrations/20250512150651_AdminOnlyLocationTypes.Designer.cs
+++ b/Muddi.ShiftPlanner.Server.Database/Migrations/20250512150651_AdminOnlyLocationTypes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Muddi.ShiftPlanner.Server.Database.Contexts;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Muddi.ShiftPlanner.Server.Database.Migrations
 {
     [DbContext(typeof(ShiftPlannerContext))]
-    partial class ShiftPlannerContextModelSnapshot : ModelSnapshot
+    [Migration("20250512150651_AdminOnlyLocationTypes")]
+    partial class AdminOnlyLocationTypes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Muddi.ShiftPlanner.Server.Database/Migrations/20250512150651_AdminOnlyLocationTypes.cs
+++ b/Muddi.ShiftPlanner.Server.Database/Migrations/20250512150651_AdminOnlyLocationTypes.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Muddi.ShiftPlanner.Server.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdminOnlyLocationTypes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "admin_only",
+                table: "shift_location_types",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "admin_only",
+                table: "shift_location_types");
+        }
+    }
+}

--- a/Muddi.ShiftPlanner.Shared/Contracts/v1/Requests/LocationTypes/CreateLocationTypeRequest.cs
+++ b/Muddi.ShiftPlanner.Shared/Contracts/v1/Requests/LocationTypes/CreateLocationTypeRequest.cs
@@ -3,4 +3,5 @@
 public class CreateLocationTypeRequest
 {
 	public string Name { get; set; }
+	public bool AdminOnly { get; set; } = false;
 }

--- a/Muddi.ShiftPlanner.Shared/Contracts/v1/Responses/LocationTypes/GetLocationTypesResponse.cs
+++ b/Muddi.ShiftPlanner.Shared/Contracts/v1/Responses/LocationTypes/GetLocationTypesResponse.cs
@@ -4,4 +4,5 @@ public class GetLocationTypesResponse : IMuddiResponse
 {
 	public Guid Id { get; set; }
 	public string Name { get; set; }
+	public bool AdminOnly { get; set; }
 }


### PR DESCRIPTION
### Summary
This pull request introduces an `AdminOnly` field to location types across the system. It includes updates to the database schema, relevant dialogs, and query enforcement to restrict access to administrators.

### Changes
- Added `AdminOnly` field to `AddLocationTypeDialog`.
- Enforced admin-only access for shift location queries.
- Created a database migration to support the new `AdminOnly` flag.
- Integrated `AdminOnly` field into location types.

### Potential Issues
Currently you can set any user to an `AdminOnly` location, this may causes confusion because normal users are able to see it in the "next shifts component" but are not able to see the location itself, so be aware of that. To fix this we have to rewrite certain parts of how users are handled to figure out which keycloak user has which roles, but I am to lazy atm to do so