### PR TITLE
feat: add greetings to customization.json

### DIFF
--- a/Muddi.ShiftPlanner.Client/Configuration/AppCustomization.cs
+++ b/Muddi.ShiftPlanner.Client/Configuration/AppCustomization.cs
@@ -7,6 +7,7 @@ public class AppCustomization
 	public string Title { get; init; } = "Schichtplanner";
 	public string Subtitle { get; init; } = string.Empty;
 	public string Contact { get; init; } = "add@me.de";
+	public string Greeting { get; init; } = "Moin";
 	public string ContactHref => (Contact.Contains('@') ? "mailto:" + Contact : "#");
 	public string StartTime { get; init; } = "08:00:00";
 	public string EndTime { get; init; } = "26:00:00";

--- a/Muddi.ShiftPlanner.Client/Pages/Index.razor
+++ b/Muddi.ShiftPlanner.Client/Pages/Index.razor
@@ -4,7 +4,7 @@
 @inject IOptions<AppCustomization> AppCustomization;
 <AuthorizeView>
 	<Authorized>
-		<h2>Buongiorno @(context.User.Identity?.Name)!</h2>
+		<h2>@AppCustomization.Value.Greeting @(context.User.Identity?.Name)!</h2>
 		<br/>
 		<StatisticsDashboardComponent/>
 		<DisplayNextShiftsComponent/>

--- a/Muddi.ShiftPlanner.Client/wwwroot/customization/customization.json
+++ b/Muddi.ShiftPlanner.Client/wwwroot/customization/customization.json
@@ -4,6 +4,7 @@
     "Subtitle": "Auf eine HAMMER-mäßige Kieler Woche 2023!",
     "Contact": "gastro@muddimarkt.org",
     "StartTime": "08:00:00",
-    "EndTime": "26:00:00"
+    "EndTime": "26:00:00",
+    "Greeting": "Moin"
   }
 }

--- a/Muddi.ShiftPlanner.Tests.Unit/JsonTests.cs
+++ b/Muddi.ShiftPlanner.Tests.Unit/JsonTests.cs
@@ -12,11 +12,12 @@ public class JsonTests
 	{
 		string json = """
 		              {
-		                "Title": "MUDDIs Schicht Planner",
-		                "Subtitle": "Auf eine HAMMER-mäßige Kieler Woche 2023!",
-		                "Contact": "gastro@muddimarkt.org",
-		                "StartTime": "08:00:00",
-		                "EndTime": "26:00:00"
+		              "Title": "MUDDIs Schicht Planner",
+		              "Subtitle": "Auf eine HAMMER-mäßige Kieler Woche 2023!",
+		              "Contact": "gastro@muddimarkt.org",
+		              "Greeting": "Buongiorno",
+		              "StartTime": "08:00:00",
+		              "EndTime": "26:00:00"
 		              }
 		              """;
 
@@ -26,20 +27,22 @@ public class JsonTests
 		customization.Title.Should().Be("MUDDIs Schicht Planner");
 		customization.Subtitle.Should().Be("Auf eine HAMMER-mäßige Kieler Woche 2023!");
 		customization.Contact.Should().Be("gastro@muddimarkt.org");
+		customization.Greeting.Should().Be("Buongiorno");
 		customization.StartTimeSpan.TotalHours.Should().Be(8);
 		customization.EndTimeSpan.TotalHours.Should().Be(26);
 	}
 
 	[Fact]
-	public void ShouldDeserializeAppCustomization_WhenValid2()
+	public void ShouldDeserializeAppCustomization_WhenValidWithDifferentTimeFormats()
 	{
 		string json = """
 		              {
-		                "Title": "MUDDIs Schicht Planner",
-		                "Subtitle": "Auf eine HAMMER-mäßige Kieler Woche 2023!",
-		                "Contact": "gastro@muddimarkt.org",
-		                "StartTime": "08:00:00",
-		                "EndTime": "1.02:00:00"
+		              "Title": "MUDDIs Schicht Planner",
+		              "Subtitle": "Auf eine HAMMER-mäßige Kieler Woche 2023!",
+		              "Contact": "gastro@muddimarkt.org",
+		              "Greeting": "Ciao",
+		              "StartTime": "08:00",
+		              "EndTime": "1.02:00:00"
 		              }
 		              """;
 
@@ -49,20 +52,22 @@ public class JsonTests
 		customization.Title.Should().Be("MUDDIs Schicht Planner");
 		customization.Subtitle.Should().Be("Auf eine HAMMER-mäßige Kieler Woche 2023!");
 		customization.Contact.Should().Be("gastro@muddimarkt.org");
+		customization.Greeting.Should().Be("Ciao");
 		customization.StartTimeSpan.TotalHours.Should().Be(8);
 		customization.EndTimeSpan.TotalHours.Should().Be(26);
 	}
 
 	[Fact]
-	public void ShouldDeserializeAppCustomization_WhenValid3()
+	public void ShouldDeserializeAppCustomization_WithMinValues()
 	{
 		string json = """
 		              {
-		                "Title": "MUDDIs Schicht Planner",
-		                "Subtitle": "Auf eine HAMMER-mäßige Kieler Woche 2023!",
-		                "Contact": "gastro@muddimarkt.org",
-		                "StartTime": "08:00",
-		                "EndTime": "26:00"
+		              "Title": "MUDDIs Schicht Planner",
+		              "Subtitle": "",
+		              "Contact": "test@example.com",
+		              "Greeting": "",
+		              "StartTime": "00:00:00",
+		              "EndTime": "00:00:00"
 		              }
 		              """;
 
@@ -70,9 +75,10 @@ public class JsonTests
 
 		customization.Should().NotBeNull();
 		customization.Title.Should().Be("MUDDIs Schicht Planner");
-		customization.Subtitle.Should().Be("Auf eine HAMMER-mäßige Kieler Woche 2023!");
-		customization.Contact.Should().Be("gastro@muddimarkt.org");
-		customization.StartTimeSpan.TotalHours.Should().Be(8);
-		customization.EndTimeSpan.TotalHours.Should().Be(26);
+		customization.Subtitle.Should().Be("");
+		customization.Contact.Should().Be("test@example.com");
+		customization.Greeting.Should().Be("");
+		customization.StartTimeSpan.TotalHours.Should().Be(0);
+		customization.EndTimeSpan.TotalHours.Should().Be(0);
 	}
 }


### PR DESCRIPTION
You can now set a greeting via the customization.json:
json
```
{
  "App": {
    // ...
    "Greeting": "Moin"
  }
}
```
Will translate in this at the front page:
<img width="567" height="276" alt="image" src="https://github.com/user-attachments/assets/62118458-998f-43c9-9264-f542e94047c2" />
