### PR TITLE
deps: upgrade to dotnet 10.0.7

### DIFF
--- a/Muddi.ShiftPlanner.Client/Muddi.ShiftPlanner.Client.csproj
+++ b/Muddi.ShiftPlanner.Client/Muddi.ShiftPlanner.Client.csproj
@@ -16,12 +16,12 @@
 	
 	<ItemGroup>
 		<PackageReference Include="BlazorDownloadFileFast" Version="1.0.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
-		<PackageReference Include="Radzen.Blazor" Version="8.3.8" />
-		<PackageReference Include="Refit.HttpClientFactory" Version="9.0.2" />
-		<PackageReference Include="Toolbelt.Blazor.PWA.Updater.Service" Version="3.1.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
+		<PackageReference Include="Radzen.Blazor" Version="10.3.2" />
+		<PackageReference Include="Refit.HttpClientFactory" Version="10.1.6" />
+		<PackageReference Include="Toolbelt.Blazor.PWA.Updater.Service" Version="3.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/CrudEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/CrudEndpoint.cs
@@ -11,8 +11,8 @@ using Serilog.Parsing;
 namespace Muddi.ShiftPlanner.Server.Api.Endpoints;
 
 public abstract class CrudEndpoint<TRequest, TResponse> : Endpoint<TRequest, TResponse>
-	where TRequest : notnull, new()
-	where TResponse : notnull, new()
+	where TRequest : notnull
+	where TResponse : notnull
 {
 	protected CrudEndpoint(ShiftPlannerContext database)
 	{

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/CrudEndpointWithoutRequest.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/CrudEndpointWithoutRequest.cs
@@ -3,7 +3,7 @@ using Muddi.ShiftPlanner.Server.Database.Contexts;
 
 namespace Muddi.ShiftPlanner.Server.Api.Endpoints;
 
-public abstract class CrudEndpointWithoutRequest<TResponse> : CrudEndpoint<EmptyRequest, TResponse> where TResponse : notnull, new()
+public abstract class CrudEndpointWithoutRequest<TResponse> : CrudEndpoint<EmptyRequest, TResponse> where TResponse : notnull
 {
 	protected CrudEndpointWithoutRequest(ShiftPlannerContext database) : base(database)
 	{

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/CrudGetAllEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/CrudGetAllEndpoint.cs
@@ -3,8 +3,8 @@
 namespace Muddi.ShiftPlanner.Server.Api.Endpoints;
 
 public abstract class CrudGetAllEndpoint<TRequest, TResponse> : CrudEndpoint<TRequest, List<TResponse>>
-	where TRequest : notnull, new()
-	where TResponse : notnull, new()
+	where TRequest : notnull
+	where TResponse : notnull
 {
 	public abstract Task<List<TResponse>?> CrudExecuteAsync(TRequest request, CancellationToken ct);
 

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/CrudGetAllEndpointWithoutRequest.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/CrudGetAllEndpointWithoutRequest.cs
@@ -4,7 +4,7 @@ using Muddi.ShiftPlanner.Server.Database.Contexts;
 namespace Muddi.ShiftPlanner.Server.Api.Endpoints;
 
 public abstract class CrudGetAllEndpointWithoutRequest<TResponse> : CrudGetAllEndpoint<EmptyRequest, TResponse>
-	where TResponse : notnull, new()
+	where TResponse : notnull
 {
 	protected CrudGetAllEndpointWithoutRequest(ShiftPlannerContext database) : base(database)
 	{

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/CrudUpdateEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/CrudUpdateEndpoint.cs
@@ -4,7 +4,7 @@ using Muddi.ShiftPlanner.Server.Database.Contexts;
 namespace Muddi.ShiftPlanner.Server.Api.Endpoints;
 
 public abstract class CrudUpdateEndpoint<TRequest> : CrudEndpoint<TRequest, EmptyResponse>
-	where TRequest : notnull, new()
+	where TRequest : notnull
 {
 	public CrudUpdateEndpoint(ShiftPlannerContext database) : base(database)
 	{

--- a/Muddi.ShiftPlanner.Server.Api/Endpoints/Seasons/SetCurrentEndpoint.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Endpoints/Seasons/SetCurrentEndpoint.cs
@@ -43,7 +43,7 @@ public class SetCurrentEndpoint : CrudEndpoint<DefaultGetRequest, EmptyResponse>
 		}
 
 		await Database.SaveChangesAsync(ct);
-		return new EmptyResponse();
+		return EmptyResponse.Instance;
 	}
 }
 

--- a/Muddi.ShiftPlanner.Server.Api/Extensions/FastEndpointResponseSenderExtensions.cs
+++ b/Muddi.ShiftPlanner.Server.Api/Extensions/FastEndpointResponseSenderExtensions.cs
@@ -6,8 +6,7 @@ namespace Muddi.ShiftPlanner.Server.Api;
 public static class FastEndpointResponseSenderExtensions
 {
 	extension<TRequest, TResponse>(ResponseSender<TRequest, TResponse> responseSender)
-		where TRequest : notnull, new()
-		where TResponse : new()
+		where TRequest : notnull
 	{
 		public Task<Void> LockedAsync(string reason, CancellationToken ct)
 			=> responseSender.StringAsync(reason, StatusCodes.Status423Locked, cancellation: ct);

--- a/Muddi.ShiftPlanner.Server.Api/Muddi.ShiftPlanner.Server.Api.csproj
+++ b/Muddi.ShiftPlanner.Server.Api/Muddi.ShiftPlanner.Server.Api.csproj
@@ -11,18 +11,18 @@
 
     <ItemGroup>
       <PackageReference Include="ClosedXML" Version="0.105.0" />
-      <PackageReference Include="Duende.AccessTokenManagement" Version="4.1.0" />
-      <PackageReference Include="FastEndpoints" Version="7.1.1" />
-      <PackageReference Include="FastEndpoints.Security" Version="7.1.1" />
-      <PackageReference Include="FastEndpoints.Swagger" Version="7.1.1" />
-      <PackageReference Include="Ical.Net" Version="5.1.3" />
-      <PackageReference Include="Mapster" Version="7.4.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+      <PackageReference Include="Duende.AccessTokenManagement" Version="4.2.0" />
+      <PackageReference Include="FastEndpoints" Version="8.1.0" />
+      <PackageReference Include="FastEndpoints.Security" Version="8.1.0" />
+      <PackageReference Include="FastEndpoints.Swagger" Version="8.1.0" />
+      <PackageReference Include="Ical.Net" Version="5.2.2" />
+      <PackageReference Include="Mapster" Version="10.0.7" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Refit.HttpClientFactory" Version="9.0.2" />
-      <PackageReference Include="Serilog" Version="4.3.0" />
+      <PackageReference Include="Refit.HttpClientFactory" Version="10.1.6" />
+      <PackageReference Include="Serilog" Version="4.3.1" />
       <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>

--- a/Muddi.ShiftPlanner.Server.Database/Muddi.ShiftPlanner.Server.Database.csproj
+++ b/Muddi.ShiftPlanner.Server.Database/Muddi.ShiftPlanner.Server.Database.csproj
@@ -7,14 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="EFCore.NamingConventions" Version="10.0.0-rc.2" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
+      <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     </ItemGroup>
 
 </Project>

--- a/Muddi.ShiftPlanner.Services.Alerting/Muddi.ShiftPlanner.Services.Alerting.csproj
+++ b/Muddi.ShiftPlanner.Services.Alerting/Muddi.ShiftPlanner.Services.Alerting.csproj
@@ -14,8 +14,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Refit.HttpClientFactory" Version="9.0.2" />
-      <PackageReference Include="Telegram.Bot" Version="22.7.5" />
+      <PackageReference Include="Refit.HttpClientFactory" Version="10.1.6" />
+      <PackageReference Include="Telegram.Bot" Version="22.10.0" />
     </ItemGroup>
 
 </Project>

--- a/Muddi.ShiftPlanner.Shared.BlazorWASM/Muddi.ShiftPlanner.Shared.BlazorWASM.csproj
+++ b/Muddi.ShiftPlanner.Shared.BlazorWASM/Muddi.ShiftPlanner.Shared.BlazorWASM.csproj
@@ -11,15 +11,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="9.0.2" />
-        <Reference Include="Microsoft.Extensions.Configuration.Abstractions">
-            <HintPath>..\..\..\..\..\..\..\Program Files\dotnet\shared\Microsoft.AspNetCore.App\6.0.5\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
-        </Reference>
-        <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
-            <HintPath>..\..\..\..\..\..\..\Program Files\dotnet\shared\Microsoft.AspNetCore.App\6.0.5\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
-        </Reference>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="10.1.6" />
     </ItemGroup>
 
 </Project>

--- a/Muddi.ShiftPlanner.Shared/Muddi.ShiftPlanner.Shared.csproj
+++ b/Muddi.ShiftPlanner.Shared/Muddi.ShiftPlanner.Shared.csproj
@@ -12,6 +12,6 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="MappingGenerator" Version="2023.7.64" />
-      <PackageReference Include="Refit" Version="9.0.2" />
+      <PackageReference Include="Refit" Version="10.1.6" />
     </ItemGroup>
 </Project>

--- a/Muddi.ShiftPlanner.Tests.Unit/Muddi.ShiftPlanner.Tests.Unit.csproj
+++ b/Muddi.ShiftPlanner.Tests.Unit/Muddi.ShiftPlanner.Tests.Unit.csproj
@@ -8,14 +8,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="8.8.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="FluentAssertions" Version="8.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
Update dependencies to dotnet 10.0.7 and
| Package | Old | New |
|---|---|---|
| `Duende.AccessTokenManagement` | 4.1.0 | 4.2.0 |
| `EFCore.NamingConventions` | 10.0.0-rc.2 | 10.0.1 |
| `FastEndpoints` | 7.1.1 | 8.1.0 |
| `FastEndpoints.Security` | 7.1.1 | 8.1.0 |
| `FastEndpoints.Swagger` | 7.1.1 | 8.1.0 |
| `FluentAssertions` | 8.8.0 | 8.9.0 |
| `Ical.Net` | 5.1.3 | 5.2.2 |
| `Mapster` | 7.4.0 | 10.0.7 |
| `Npgsql.EntityFrameworkCore.PostgreSQL` | 10.0.0 | 10.0.1 |
| `Radzen.Blazor` | 8.3.8 | 10.3.2 |
| `Refit` | 9.0.2 | 10.1.6 |
| `Refit.HttpClientFactory` | 9.0.2 | 10.1.6 |
| `Serilog` | 4.3.0 | 4.3.1 |
| `Telegram.Bot` | 22.7.5 | 22.10.0 |
| `Toolbelt.Blazor.PWA.Updater.Service` | 3.1.0 | 3.2.0 |
| `coverlet.collector` | 6.0.4 | 10.0.0 |