### PR TITLE
fix: cache appSettings for splash image

### DIFF
--- a/Muddi.ShiftPlanner.Client/Services/AppSettingsService.cs
+++ b/Muddi.ShiftPlanner.Client/Services/AppSettingsService.cs
@@ -1,6 +1,9 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Muddi.ShiftPlanner.Shared.Api;
 using Muddi.ShiftPlanner.Shared.Contracts.v1.Requests;
 using Muddi.ShiftPlanner.Shared.Entities;
+using Microsoft.JSInterop;
 
 namespace Muddi.ShiftPlanner.Client.Services;
 
@@ -12,23 +15,23 @@ namespace Muddi.ShiftPlanner.Client.Services;
 /// </summary>
 public class AppSettingsService
 {
+	private const string LocalStorageKey = "appSettings";
+
 	/// <summary>
 	/// Values used until the real settings load, or whenever the API is unreachable.
 	/// </summary>
-	public static ApplicationSettings Defaults { get; } = new()
+	private static readonly ApplicationSettings Defaults = new();
+
+	private static readonly JsonSerializerOptions JsonSerializerOptions = new()
 	{
-		Title = "MUDDIs Schicht Planner",
-		Subtitle = string.Empty,
-		Contact = string.Empty,
-		StartTime = new TimeSpan(8, 0, 0),
-		EndTime = new TimeSpan(26, 0, 0),
-		Greeting = "Moin",
-		MemberName = "MUDDIs"
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase
 	};
 
 	private readonly IMuddiShiftApi _api;
+	private readonly IJSRuntime _jsRuntime;
+	private readonly ILogger<AppSettingsService> _logger;
 	private Lazy<Task<ApplicationSettings>> _lazySettings;
-	private ApplicationSettings _current = Defaults;
+
 
 	/// <summary>
 	/// Raised when the effective settings change — on the first successful load and on every update.
@@ -38,11 +41,13 @@ public class AppSettingsService
 	/// <summary>
 	/// The most recently known settings. Equals <see cref="Defaults"/> until the first successful load.
 	/// </summary>
-	public ApplicationSettings Current => _current;
+	public ApplicationSettings Current { get; private set; } = Defaults;
 
-	public AppSettingsService(IMuddiShiftApi api)
+	public AppSettingsService(IMuddiShiftApi api, IJSRuntime jsRuntime, ILogger<AppSettingsService> logger)
 	{
 		_api = api;
+		_jsRuntime = jsRuntime;
+		_logger = logger;
 		_lazySettings = new Lazy<Task<ApplicationSettings>>(LoadAsync);
 	}
 
@@ -89,14 +94,46 @@ public class AppSettingsService
 	{
 		var response = await _api.GetAppSettings();
 		SetCurrent(response.Settings);
+		await SaveToLocalStorageAsync(response.Settings);
 		return response.Settings;
+	}
+
+	private async Task SaveToLocalStorageAsync(ApplicationSettings settings)
+	{
+		try
+		{
+			var json = JsonSerializer.Serialize(settings, JsonSerializerOptions);
+			await _jsRuntime.InvokeVoidAsync("localStorage.setItem", LocalStorageKey, json);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Failed to save settings to localStorage");
+		}
+	}
+
+	/// <summary>
+	/// Loads settings from localStorage, returning null if nothing is cached.
+	/// </summary>
+	public async Task<ApplicationSettings?> GetCachedSettingsAsync()
+	{
+		try
+		{
+			var json = await _jsRuntime.InvokeAsync<string?>("localStorage.getItem", LocalStorageKey);
+			if (string.IsNullOrEmpty(json)) return null;
+			return JsonSerializer.Deserialize<ApplicationSettings>(json, JsonSerializerOptions);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Failed to load settings from localStorage");
+			return null;
+		}
 	}
 
 	private void SetCurrent(ApplicationSettings settings)
 	{
-		if (_current == settings)
+		if (Current == settings)
 			return;
-		_current = settings;
+		Current = settings;
 		SettingsChanged?.Invoke(this, settings);
 	}
 }

--- a/Muddi.ShiftPlanner.Client/Shared/MainLayout.razor
+++ b/Muddi.ShiftPlanner.Client/Shared/MainLayout.razor
@@ -11,82 +11,94 @@
 <RadzenTooltip/>
 <RadzenContextMenu/>
 <CascadingValue Value="this">
-    <CascadingValue Value="_settings" IsFixed="false">
+    @if (_settings is not null)
+    {
+        <CascadingValue Value="_settings" IsFixed="false">
         <RadzenLayout>
-        <RadzenHeader>
-            <ChildContent>
-                <div class="d-flex justify-content-between align-items-center" style="background:#fff;">
-                    <div class="d-flex align-items-center w-100">
-                        <RadzenSidebarToggle Click="@(_ => { _sidebarExpanded = !_sidebarExpanded; _bodyExpanded = !_bodyExpanded; })">
-                        </RadzenSidebarToggle>
-                        <RadzenLink class="title" Text="@($"{_settings.Title} {(string.IsNullOrEmpty(_title) ? "" : "» ")}")" Path="/"></RadzenLink>
-                        <RadzenLabel Text=@_title class="title-page mx-2"></RadzenLabel>
+            <RadzenHeader>
+                <ChildContent>
+                    <div class="d-flex justify-content-between align-items-center" style="background:#fff;">
+                        <div class="d-flex align-items-center w-100">
+                            <RadzenSidebarToggle Click="@(_ =>
+                                                        {
+                                                            _sidebarExpanded = !_sidebarExpanded;
+                                                            _bodyExpanded = !_bodyExpanded;
+                                                        })">
+                            </RadzenSidebarToggle>
+                            <RadzenLink class="title"
+                                        Text="@($"{_settings.Title} {(string.IsNullOrEmpty(_title) ? "" : "» ")}")"
+                                        Path="/"></RadzenLink>
+                            <RadzenLabel Text=@_title class="title-page mx-2"></RadzenLabel>
 
-                    </div>
-                    <div class="d-flex align-items-center justify-content-end">
-                        <a href="/help">
-                            <RadzenIcon Icon="help"
-                                        class="title-bar-icon"
-                                        MouseEnter="@(reference => TooltipService.Open(reference, "Hilfe", new() { Position = TooltipPosition.Left }))">
-                            </RadzenIcon>
-                        </a>
-                        <a href="/authentication/logout">
-                            <RadzenIcon Icon="account_circle"
-                                        class="title-bar-icon"
-                                        MouseEnter="@(reference => TooltipService.Open(reference, "Logout", new() { Position = TooltipPosition.Left }))">
-                            </RadzenIcon>
-                        </a>
-                        @*	<a href="https://github.com/muddi-markt" title="GitHub" target="_blank" class="mx-3">
+                        </div>
+                        <div class="d-flex align-items-center justify-content-end">
+                            <a href="/help">
+                                <RadzenIcon Icon="help"
+                                            class="title-bar-icon"
+                                            MouseEnter="@(reference => TooltipService.Open(reference, "Hilfe", new() { Position = TooltipPosition.Left }))">
+                                </RadzenIcon>
+                            </a>
+                            <a href="/authentication/logout">
+                                <RadzenIcon Icon="account_circle"
+                                            class="title-bar-icon"
+                                            MouseEnter="@(reference => TooltipService.Open(reference, "Logout", new() { Position = TooltipPosition.Left }))">
+                                </RadzenIcon>
+                            </a>
+                            @*	<a href="https://github.com/muddi-markt" title="GitHub" target="_blank" class="mx-3">
 							<svg width="24" height="24" viewBox="0 0 512 499.36" xmlns="http://www.w3.org/2000/svg">
 								<path fill="black" fill-rule="evenodd" d="M256 0C114.64 0 0 114.61 0 256c0 113.09 73.34 209 175.08 242.9 12.8 2.35 17.47-5.56 17.47-12.34 0-6.08-.22-22.18-.35-43.54-71.2 15.49-86.2-34.34-86.2-34.34-11.64-29.57-28.42-37.45-28.42-37.45-23.27-15.84 1.73-15.55 1.73-15.55 25.69 1.81 39.21 26.38 39.21 26.38 22.84 39.12 59.92 27.82 74.5 21.27 2.33-16.54 8.94-27.82 16.25-34.22-56.84-6.43-116.6-28.43-116.6-126.49 0-27.95 10-50.8 26.35-68.69-2.63-6.48-11.42-32.5 2.51-67.75 0 0 21.49-6.88 70.4 26.24a242.65 0 0 1 128.18 0c48.87-33.13 70.33-26.24 70.33-26.24 14 35.25 5.18 61.27 2.55 67.75 16.41 17.9 26.31 40.75 26.31 68.69 0 98.35-59.85 120-116.88 126.32 9.19 7.9 17.38 23.53 17.38 47.41 0 34.22-.31 61.83-.31 70.23 0 6.85 4.61 14.81 17.6 12.31C438.72 464.97 512 369.08 512 256.02 512 114.62 397.37 0 256 0z"></path>
 							</svg>
 						</a>
 						*@
+                        </div>
                     </div>
-                </div>
-            </ChildContent>
-        </RadzenHeader>
-        <RadzenBody @bind-Expanded="@_bodyExpanded">
-            <ChildContent>
-                <RadzenContentContainer Name="main">
-                    <div class="container-fluid h-100">
-                        <div class="row h-100 align-content-between justify-content-around">
-                            <div class="col-12 pt-4 pb-5 px-0 px-lg-5">
-                                <ErrorBoundary >
-                                    <ChildContent>
-                                        @Body
-                                    </ChildContent>
-                                    <ErrorContent>
-                                        @if (context is AccessTokenNotAvailableException)
-                                        {
-                                            <RedirectToLogin/>
-                                        }
-                                        else
-                                        {
-                                            <div class="blazor-error-boundary">
-                                                @context.Message <br/>
-                                            </div>
-                                            <button class="rz-button" onClick="window.location.reload();">Reload</button>
-                                        }
+                </ChildContent>
+            </RadzenHeader>
+            <RadzenBody @bind-Expanded="@_bodyExpanded">
+                <ChildContent>
+                    <RadzenContentContainer Name="main">
+                        <div class="container-fluid h-100">
+                            <div class="row h-100 align-content-between justify-content-around">
+                                <div class="col-12 pt-4 pb-5 px-0 px-lg-5">
+                                    <ErrorBoundary>
+                                        <ChildContent>
+                                            @Body
+                                        </ChildContent>
+                                        <ErrorContent>
+                                            @if (context is AccessTokenNotAvailableException)
+                                            {
+                                                <RedirectToLogin/>
+                                            }
+                                            else
+                                            {
+                                                <div class="blazor-error-boundary">
+                                                    @context.Message <br/>
+                                                </div>
+                                                <button class="rz-button" onClick="window.location.reload();">Reload
+                                                </button>
+                                            }
 
-                                    </ErrorContent>
-                                </ErrorBoundary>
-                            </div>
-                            <div class="d-flex flex-column align-items-center text-center pb-3">
-                                <RadzenLabel Text="MUDDI Markt Shift Planner"></RadzenLabel>
-                                <div class="d-flex" style="gap: 4px">
-                                    <RadzenLabel Text="&copy; 2022-2025 Max Reble,"></RadzenLabel>
-                                    <RadzenLink Target="_blank" Path="https://muddimarkt.org">MUDDI Markt e.V.</RadzenLink>
+                                        </ErrorContent>
+                                    </ErrorBoundary>
+                                </div>
+                                <div class="d-flex flex-column align-items-center text-center pb-3">
+                                    <RadzenLabel Text="MUDDI Markt Shift Planner"></RadzenLabel>
+                                    <div class="d-flex" style="gap: 4px">
+                                        <RadzenLabel Text="&copy; 2022-2025 Max Reble,"></RadzenLabel>
+                                        <RadzenLink Target="_blank" Path="https://muddimarkt.org">MUDDI Markt e.V.
+                                        </RadzenLink>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </RadzenContentContainer>
-            </ChildContent>
-        </RadzenBody>
-        <NavMenu @bind-Expanded="_sidebarExpanded"></NavMenu>
-    </RadzenLayout>
+                    </RadzenContentContainer>
+                </ChildContent>
+            </RadzenBody>
+            <NavMenu @bind-Expanded="_sidebarExpanded"></NavMenu>
+        </RadzenLayout>
     </CascadingValue>
+    }
+    
 </CascadingValue>
 <RadzenMediaQuery Query="(max-width: 768px)" Change="MediaQueryCallback"></RadzenMediaQuery>
 
@@ -97,10 +109,17 @@
     private bool _isMediaMaxWidth768;
 
     private List<ShiftLocation> _locations = new();
-    private ApplicationSettings _settings = AppSettingsService.Defaults;
+    private ApplicationSettings? _settings;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
+        // Try cached settings first to fasten up first display
+        var cached = await AppSettingsService.GetCachedSettingsAsync();
+        if (cached != null)
+        {
+            _settings = cached;
+        }
+
         AppSettingsService.SettingsChanged += (_, settings) =>
         {
             _settings = settings;
@@ -116,6 +135,10 @@
         };
     }
 
+    protected override void OnInitialized()
+    {
+    }
+
     protected override async Task OnParametersSetAsync()
     {
         try
@@ -127,6 +150,8 @@
             {
                 await ShiftService.Initialize();
                 _locations = ShiftService.GetAllShiftLocations().ToList();
+
+                // Fetch fresh from API (overwrites cache if different)
                 await AppSettingsService.GetSettingsAsync();
             }
         }
@@ -154,4 +179,5 @@
     {
         _isMediaMaxWidth768 = obj;
     }
+
 }

--- a/Muddi.ShiftPlanner.Client/wwwroot/index.html
+++ b/Muddi.ShiftPlanner.Client/wwwroot/index.html
@@ -14,7 +14,7 @@
 
     <link href="Muddi.ShiftPlanner.Client.styles.css?{{VERSION}}" rel="stylesheet"/>
 
-    
+
     <link href="manifest.json" rel="manifest"/>
     <link rel="apple-touch-icon" sizes="192x192" href="customization/favicon.png"/>
     <link rel="icon" type="image/png" href="customization/favicon.png"/>
@@ -50,7 +50,7 @@
 <script src="_content/Radzen.Blazor/Radzen.Blazor.js?{{VERSION}}"></script>
 <script src="_framework/blazor.webassembly.js"></script>
 <!--<script>navigator.serviceWorker.register('/service-worker.js', {updateViaCache: 'none'});</script>-->
-<script src="_content/Toolbelt.Blazor.PWA.Updater.Service/script.min.js?v3.0.1"></script>
+<script src="_content/Toolbelt.Blazor.PWA.Updater.Service/script.min.js?v3.2.0"></script>
 
 </body>
 

--- a/Muddi.ShiftPlanner.Client/wwwroot/js/shift-planner.js
+++ b/Muddi.ShiftPlanner.Client/wwwroot/js/shift-planner.js
@@ -1,1 +1,29 @@
 // shift-planner.js - JavaScript helpers for the ShiftPlanner client
+
+/**
+ * Reads app settings from localStorage and applies them to the page.
+ * Called early so the user sees correct values before Blazor boots.
+ */
+function applyCachedAppSettings() {
+    try {
+        const cached = localStorage.getItem('appSettings');
+        if (!cached) return;
+
+        const settings = JSON.parse(cached);
+        if (!settings) return;
+
+        // Update the loading placeholder in index.html
+        const h1 = document.querySelector('.muddi-plain-content h1');
+        const p = document.querySelector('.muddi-plain-content p');
+        if (h1) h1.textContent = settings.title || '';
+        if (p) p.textContent = settings.subtitle || '';
+
+        // Update page title
+        if (settings.title) document.title = settings.title;
+    } catch (error) {
+        console.warn('Could not apply cached app settings:', error);
+    }
+}
+
+// Apply immediately when this script loads
+applyCachedAppSettings();


### PR DESCRIPTION
This caches the appsettings in the `localStorage` to let the appSettings also show in pre-blazor (javascript) phase for the splash image. Also fixes the flashing of another greeting on the main page.