### PR TITLE
hotfix: when settings is not yet cached, nothing was displayed

### DIFF
--- a/Muddi.ShiftPlanner.Client/Services/AppSettingsService.cs
+++ b/Muddi.ShiftPlanner.Client/Services/AppSettingsService.cs
@@ -114,18 +114,19 @@ public class AppSettingsService
 	/// <summary>
 	/// Loads settings from localStorage, returning null if nothing is cached.
 	/// </summary>
-	public async Task<ApplicationSettings?> GetCachedSettingsAsync()
+	public async Task<ApplicationSettings> GetCachedOrDefaultSettingsAsync()
 	{
 		try
 		{
 			var json = await _jsRuntime.InvokeAsync<string?>("localStorage.getItem", LocalStorageKey);
-			if (string.IsNullOrEmpty(json)) return null;
-			return JsonSerializer.Deserialize<ApplicationSettings>(json, JsonSerializerOptions);
+			if (string.IsNullOrEmpty(json))
+				return Defaults;
+			return JsonSerializer.Deserialize<ApplicationSettings>(json, JsonSerializerOptions) ?? Defaults;
 		}
 		catch (Exception ex)
 		{
 			_logger.LogError(ex, "Failed to load settings from localStorage");
-			return null;
+			return Defaults;
 		}
 	}
 

--- a/Muddi.ShiftPlanner.Client/Shared/MainLayout.razor
+++ b/Muddi.ShiftPlanner.Client/Shared/MainLayout.razor
@@ -14,91 +14,91 @@
     @if (_settings is not null)
     {
         <CascadingValue Value="_settings" IsFixed="false">
-        <RadzenLayout>
-            <RadzenHeader>
-                <ChildContent>
-                    <div class="d-flex justify-content-between align-items-center" style="background:#fff;">
-                        <div class="d-flex align-items-center w-100">
-                            <RadzenSidebarToggle Click="@(_ =>
-                                                        {
-                                                            _sidebarExpanded = !_sidebarExpanded;
-                                                            _bodyExpanded = !_bodyExpanded;
-                                                        })">
-                            </RadzenSidebarToggle>
-                            <RadzenLink class="title"
-                                        Text="@($"{_settings.Title} {(string.IsNullOrEmpty(_title) ? "" : "» ")}")"
-                                        Path="/"></RadzenLink>
-                            <RadzenLabel Text=@_title class="title-page mx-2"></RadzenLabel>
+            <RadzenLayout>
+                <RadzenHeader>
+                    <ChildContent>
+                        <div class="d-flex justify-content-between align-items-center" style="background:#fff;">
+                            <div class="d-flex align-items-center w-100">
+                                <RadzenSidebarToggle Click="@(_ =>
+                                                            {
+                                                                _sidebarExpanded = !_sidebarExpanded;
+                                                                _bodyExpanded = !_bodyExpanded;
+                                                            })">
+                                </RadzenSidebarToggle>
+                                <RadzenLink class="title"
+                                            Text="@($"{_settings.Title} {(string.IsNullOrEmpty(_title) ? "" : "» ")}")"
+                                            Path="/"></RadzenLink>
+                                <RadzenLabel Text=@_title class="title-page mx-2"></RadzenLabel>
 
-                        </div>
-                        <div class="d-flex align-items-center justify-content-end">
-                            <a href="/help">
-                                <RadzenIcon Icon="help"
-                                            class="title-bar-icon"
-                                            MouseEnter="@(reference => TooltipService.Open(reference, "Hilfe", new() { Position = TooltipPosition.Left }))">
-                                </RadzenIcon>
-                            </a>
-                            <a href="/authentication/logout">
-                                <RadzenIcon Icon="account_circle"
-                                            class="title-bar-icon"
-                                            MouseEnter="@(reference => TooltipService.Open(reference, "Logout", new() { Position = TooltipPosition.Left }))">
-                                </RadzenIcon>
-                            </a>
-                            @*	<a href="https://github.com/muddi-markt" title="GitHub" target="_blank" class="mx-3">
+                            </div>
+                            <div class="d-flex align-items-center justify-content-end">
+                                <a href="/help">
+                                    <RadzenIcon Icon="help"
+                                                class="title-bar-icon"
+                                                MouseEnter="@(reference => TooltipService.Open(reference, "Hilfe", new() { Position = TooltipPosition.Left }))">
+                                    </RadzenIcon>
+                                </a>
+                                <a href="/authentication/logout">
+                                    <RadzenIcon Icon="account_circle"
+                                                class="title-bar-icon"
+                                                MouseEnter="@(reference => TooltipService.Open(reference, "Logout", new() { Position = TooltipPosition.Left }))">
+                                    </RadzenIcon>
+                                </a>
+                                @*	<a href="https://github.com/muddi-markt" title="GitHub" target="_blank" class="mx-3">
 							<svg width="24" height="24" viewBox="0 0 512 499.36" xmlns="http://www.w3.org/2000/svg">
 								<path fill="black" fill-rule="evenodd" d="M256 0C114.64 0 0 114.61 0 256c0 113.09 73.34 209 175.08 242.9 12.8 2.35 17.47-5.56 17.47-12.34 0-6.08-.22-22.18-.35-43.54-71.2 15.49-86.2-34.34-86.2-34.34-11.64-29.57-28.42-37.45-28.42-37.45-23.27-15.84 1.73-15.55 1.73-15.55 25.69 1.81 39.21 26.38 39.21 26.38 22.84 39.12 59.92 27.82 74.5 21.27 2.33-16.54 8.94-27.82 16.25-34.22-56.84-6.43-116.6-28.43-116.6-126.49 0-27.95 10-50.8 26.35-68.69-2.63-6.48-11.42-32.5 2.51-67.75 0 0 21.49-6.88 70.4 26.24a242.65 0 0 1 128.18 0c48.87-33.13 70.33-26.24 70.33-26.24 14 35.25 5.18 61.27 2.55 67.75 16.41 17.9 26.31 40.75 26.31 68.69 0 98.35-59.85 120-116.88 126.32 9.19 7.9 17.38 23.53 17.38 47.41 0 34.22-.31 61.83-.31 70.23 0 6.85 4.61 14.81 17.6 12.31C438.72 464.97 512 369.08 512 256.02 512 114.62 397.37 0 256 0z"></path>
 							</svg>
 						</a>
 						*@
+                            </div>
                         </div>
-                    </div>
-                </ChildContent>
-            </RadzenHeader>
-            <RadzenBody @bind-Expanded="@_bodyExpanded">
-                <ChildContent>
-                    <RadzenContentContainer Name="main">
-                        <div class="container-fluid h-100">
-                            <div class="row h-100 align-content-between justify-content-around">
-                                <div class="col-12 pt-4 pb-5 px-0 px-lg-5">
-                                    <ErrorBoundary>
-                                        <ChildContent>
-                                            @Body
-                                        </ChildContent>
-                                        <ErrorContent>
-                                            @if (context is AccessTokenNotAvailableException)
-                                            {
-                                                <RedirectToLogin/>
-                                            }
-                                            else
-                                            {
-                                                <div class="blazor-error-boundary">
-                                                    @context.Message <br/>
-                                                </div>
-                                                <button class="rz-button" onClick="window.location.reload();">Reload
-                                                </button>
-                                            }
+                    </ChildContent>
+                </RadzenHeader>
+                <RadzenBody @bind-Expanded="@_bodyExpanded">
+                    <ChildContent>
+                        <RadzenContentContainer Name="main">
+                            <div class="container-fluid h-100">
+                                <div class="row h-100 align-content-between justify-content-around">
+                                    <div class="col-12 pt-4 pb-5 px-0 px-lg-5">
+                                        <ErrorBoundary>
+                                            <ChildContent>
+                                                @Body
+                                            </ChildContent>
+                                            <ErrorContent>
+                                                @if (context is AccessTokenNotAvailableException)
+                                                {
+                                                    <RedirectToLogin/>
+                                                }
+                                                else
+                                                {
+                                                    <div class="blazor-error-boundary">
+                                                        @context.Message <br/>
+                                                    </div>
+                                                    <button class="rz-button" onClick="window.location.reload();">Reload
+                                                    </button>
+                                                }
 
-                                        </ErrorContent>
-                                    </ErrorBoundary>
-                                </div>
-                                <div class="d-flex flex-column align-items-center text-center pb-3">
-                                    <RadzenLabel Text="MUDDI Markt Shift Planner"></RadzenLabel>
-                                    <div class="d-flex" style="gap: 4px">
-                                        <RadzenLabel Text="&copy; 2022-2025 Max Reble,"></RadzenLabel>
-                                        <RadzenLink Target="_blank" Path="https://muddimarkt.org">MUDDI Markt e.V.
-                                        </RadzenLink>
+                                            </ErrorContent>
+                                        </ErrorBoundary>
+                                    </div>
+                                    <div class="d-flex flex-column align-items-center text-center pb-3">
+                                        <RadzenLabel Text="MUDDI Markt Shift Planner"></RadzenLabel>
+                                        <div class="d-flex" style="gap: 4px">
+                                            <RadzenLabel Text="&copy; 2022-2025 Max Reble,"></RadzenLabel>
+                                            <RadzenLink Target="_blank" Path="https://muddimarkt.org">MUDDI Markt e.V.
+                                            </RadzenLink>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                    </RadzenContentContainer>
-                </ChildContent>
-            </RadzenBody>
-            <NavMenu @bind-Expanded="_sidebarExpanded"></NavMenu>
-        </RadzenLayout>
-    </CascadingValue>
+                        </RadzenContentContainer>
+                    </ChildContent>
+                </RadzenBody>
+                <NavMenu @bind-Expanded="_sidebarExpanded"></NavMenu>
+            </RadzenLayout>
+        </CascadingValue>
     }
-    
+
 </CascadingValue>
 <RadzenMediaQuery Query="(max-width: 768px)" Change="MediaQueryCallback"></RadzenMediaQuery>
 
@@ -114,15 +114,12 @@
     protected override async Task OnInitializedAsync()
     {
         // Try cached settings first to fasten up first display
-        var cached = await AppSettingsService.GetCachedSettingsAsync();
-        if (cached != null)
-        {
-            _settings = cached;
-        }
+        _settings = await AppSettingsService.GetCachedOrDefaultSettingsAsync();
+        
 
-        AppSettingsService.SettingsChanged += (_, settings) =>
+        AppSettingsService.SettingsChanged += (_, appSettings) =>
         {
-            _settings = settings;
+            _settings = appSettings;
             InvokeAsync(StateHasChanged);
         };
         NavigationManager.LocationChanged += (_, _) =>

--- a/Muddi.ShiftPlanner.Client/Shared/MainLayout.razor
+++ b/Muddi.ShiftPlanner.Client/Shared/MainLayout.razor
@@ -11,7 +11,14 @@
 <RadzenTooltip/>
 <RadzenContextMenu/>
 <CascadingValue Value="this">
-    @if (_settings is not null)
+    @if (_settings is null)
+    {
+        <div class="muddi-plain-content mt-5">
+            <LoadingSpinner/>
+            <p>Lade Einstellungen...</p>
+        </div>
+    }
+    else
     {
         <CascadingValue Value="_settings" IsFixed="false">
             <RadzenLayout>
@@ -98,7 +105,6 @@
             </RadzenLayout>
         </CascadingValue>
     }
-
 </CascadingValue>
 <RadzenMediaQuery Query="(max-width: 768px)" Change="MediaQueryCallback"></RadzenMediaQuery>
 
@@ -115,7 +121,7 @@
     {
         // Try cached settings first to fasten up first display
         _settings = await AppSettingsService.GetCachedOrDefaultSettingsAsync();
-        
+
 
         AppSettingsService.SettingsChanged += (_, appSettings) =>
         {
@@ -130,10 +136,6 @@
             _bodyExpanded = true;
             InvokeAsync(StateHasChanged);
         };
-    }
-
-    protected override void OnInitialized()
-    {
     }
 
     protected override async Task OnParametersSetAsync()


### PR DESCRIPTION
When an user opens this app for the very first time, only a blank screen was displayed. This is now fixed with this PR