### PR TITLE
chore: beautify edit dialog by changing how description is shown

### DIFF
--- a/Muddi.ShiftPlanner.Client/Pages/Locations/EditShiftDialog.razor
+++ b/Muddi.ShiftPlanner.Client/Pages/Locations/EditShiftDialog.razor
@@ -5,9 +5,23 @@
 
 @if (_user is not null && EntityToEdit.Type is not null)
 {
-	@if (_isAdmin)
+	if (EntityToEdit.Type?.Name is { } typeName)
 	{
-		<h3>Admin Mode</h3>
+		<div style="display: flex; gap: 4px">
+			<h3>@typeName</h3>
+			@if (_isAdmin)
+			{
+				<h5 style="color: #555">Admin Mode</h5>
+			}
+		</div>
+	}
+
+
+	@if (EntityToEdit.Type?.Description is { } description)
+	{
+		<p style="width:100%;font-style: italic">
+			@description
+		</p>
 	}
 
 	<div class="row">
@@ -18,6 +32,7 @@
 			@if (_employeesToSelect is null)
 			{
 				<RadzenTextBox
+					Style="width: 200px"
 					ReadOnly="true"
 					Value="@($"{EntityToEdit.EmployeeFullName} {(_isShiftUser ? "(Das bist du!)" : "")}")">
 				</RadzenTextBox>
@@ -90,19 +105,6 @@
 
 
 	</div>
-	@if (EntityToEdit.Type?.Description is { } description)
-	{
-		<div class="row">
-			<div class="col-md-4 align-items-center d-flex">
-				<RadzenLabel Text="Deine Aufgabe:"/>
-			</div>
-			<div class="col-md-8">
-				<p class="rz-textarea" style="width:200px;">
-					@description
-				</p>
-			</div>
-		</div>
-	}
 
 	@if (_isAdmin)
 	{


### PR DESCRIPTION
### Instead of 
<img width="467" height="421" alt="image" src="https://github.com/user-attachments/assets/0e8cd341-55f7-409e-ae2c-5150bdff79dc" />

### Description looks like this now
<img width="684" height="343" alt="image" src="https://github.com/user-attachments/assets/8a45fc37-c85a-4d0c-bd20-dc6d9324d42d" />
